### PR TITLE
Tests namespace is not compilant with PSR-0 warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Test\\Net\\Bazzline\\Component\\Lock\\": "test/"
+            "Net\\Bazzline\\Component\\Lock\\Test\\": "test/"
         }
     }
 }

--- a/test/FileHandlerLockAsResourceTest.php
+++ b/test/FileHandlerLockAsResourceTest.php
@@ -3,7 +3,7 @@
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-09-08
  */
-namespace Test\Net\Bazzline\Component\Lock;
+namespace Net\Bazzline\Component\Lock\Test;
 
 use Net\Bazzline\Component\Lock\FileHandlerLock;
 use Net\Bazzline\Component\Lock\LockInterface;

--- a/test/FileHandlerLockAsSplFileObjectTest.php
+++ b/test/FileHandlerLockAsSplFileObjectTest.php
@@ -3,7 +3,7 @@
  * @author stev leibelt <artodeto@bazzline.net>
  * @since 2015-09-08
  */
-namespace Test\Net\Bazzline\Component\Lock;
+namespace Net\Bazzline\Component\Lock\Test;
 
 use Net\Bazzline\Component\Lock\FileHandlerLock;
 use Net\Bazzline\Component\Lock\LockInterface;

--- a/test/FileLockTest.php
+++ b/test/FileLockTest.php
@@ -4,7 +4,7 @@
  * @since 2013-06-30 
  */
 
-namespace Test\Net\Bazzline\Component\Lock;
+namespace Net\Bazzline\Component\Lock\Test;
 
 use Net\Bazzline\Component\Lock\FileNameLock;
 use Net\Bazzline\Component\Lock\LockInterface;

--- a/test/RuntimeLockTest.php
+++ b/test/RuntimeLockTest.php
@@ -4,7 +4,7 @@
  * @since 2013-06-30 
  */
 
-namespace Test\Net\Bazzline\Component\Lock;
+namespace Net\Bazzline\Component\Lock\Test;
 
 use Net\Bazzline\Component\Lock\LockInterface;
 use Net\Bazzline\Component\Lock\RuntimeLock;


### PR DESCRIPTION
Fixing deprecation notice: Class Test\Net\Bazzline\Component\Lock\FileLockTest located in ./vendor/net_bazzline/component_lock/test/Net/Bazzline/Component/Lock/FileLockTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0.

Full log:

```
Deprecation Notice: Class Test\Net\Bazzline\Component\Lock\FileLockTest located in ./vendor/net_bazzline/component_lock/test/Net/Bazzline/Component/Lock/FileLockTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Test\Net\Bazzline\Component\Lock\FileHandlerLockAsResourceTest located in ./vendor/net_bazzline/component_lock/test/Net/Bazzline/Component/Lock/FileHandlerLockAsResourceTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Test\Net\Bazzline\Component\Lock\RuntimeLockTest located in ./vendor/net_bazzline/component_lock/test/Net/Bazzline/Component/Lock/RuntimeLockTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Test\Net\Bazzline\Component\Lock\FileHandlerLockAsSplFileObjectTest located in ./vendor/net_bazzline/component_lock/test/Net/Bazzline/Component/Lock/FileHandlerLockAsSplFileObjectTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Net\Bazzline\Component\Curl\Option\Behaviour\SetTcpNoDelayMixed located in ./vendor/net_bazzline/php_component_curl/source/Option/Behaviour/SetTcpNoDelay.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

```